### PR TITLE
Add database socket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If you cloned the whole repository, simply run: `npm install`
       - NF_TOKEN
       - NF_URL
       - NF_DB_HOST     (default: 127.0.0.1)
+      - NF_DB_SOCKETPATH 
       - NF_DB_USER
       - NF_DB_PASSWORD
       - NF_DB_DATABASE
@@ -29,7 +30,7 @@ you like to use it with a different DB format, you can specify a custom JSON
 formatted config file with adjusted column names via `NF_DB_COLS_CONF`. The
 format should look like so:
 
-```
+```json
 {
   "gym": { "table": "gymdetails", "imageCol": "url", "id": "gym_id", "type": "gyms" },
   "stop": { "table": "pokestop", "imageCol": "image", "id": "pokestop_id", "type": "stops" }
@@ -47,4 +48,3 @@ format should look like so:
     - add ability to specify a different column format / names via `NF_DB_COLS_CONF`
   * 2021-02-20:
     - add Dockerfile
-

--- a/name_fetcher.js
+++ b/name_fetcher.js
@@ -11,10 +11,11 @@ let token = '' // the one provided on Discord with this script
 let url = ''   // also provided on Discord
 let dbConfig = {
   'host': '127.0.0.1',
+  'socketPath': '',
   'user': '',
   'password': '',
   'database': '',
-  'port': '3306',
+  'port': '3306'
 }
 
 // don't edit anything below this line
@@ -32,6 +33,7 @@ try {
   token = process.env.NF_TOKEN || token
   url = process.env.NF_URL || url
   dbConfig.host = process.env.NF_DB_HOST || dbConfig.host
+  dbConfig.socketPath = process.env.NF_DB_SOCKETPATH || dbConfig.socketPath
   dbConfig.user = process.env.NF_DB_USER || dbConfig.user
   dbConfig.password = process.env.NF_DB_PASSWORD || dbConfig.password
   dbConfig.database = process.env.NF_DB_DATABASE || dbConfig.database


### PR DESCRIPTION
The socketPath config parameter is only used when set. Tested with a "normal" tcp connection and with a socket file